### PR TITLE
Fix typo in the description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # pss-lrev
-Multi-modal Page stream segmation with Convolutional Neural Networks
+Multi-modal page stream segmentation with convolutional neural networks


### PR DESCRIPTION
It's written "segmation", but the paper title actually says "segmentation". So I copied the proper paper title from [Springer Link](https://link.springer.com/article/10.1007/s10579-019-09476-2) to the project description.
